### PR TITLE
Use https in Gemfile source

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-source 'http://rubygems.org'
+source 'https://rubygems.org'
 gemspec
 # gem 'rubocop', require: true, group: :test
 gem 'simplecov', require: false, group: :test


### PR DESCRIPTION
https://github.com/rewindio/jsonpath/security/code-scanning/1

Using http leaves bundling vulnerable to potential MITM attacks.