### PR TITLE
chore(): pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,17 @@
+version: 2
+
+updates:
+  # Maintain dependencies for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "appsec"
+    open-pull-requests-limit: 10
+    groups:
+      minor-and-patch:
+        applies-to: version-updates
+        update-types:
+        - "patch"
+        - "minor"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,31 +1,31 @@
 name: test
 on:
-- push
-- pull_request
+  - push
+  - pull_request
 jobs:
   test:
     strategy:
       fail-fast: false
       matrix:
         ruby-version:
-        - '2.5'
-        - '2.6'
-        - '2.7'
-        - ruby-head
-        - jruby-head
-        - truffleruby-head
+          - '2.5'
+          - '2.6'
+          - '2.7'
+          - ruby-head
+          - jruby-head
+          - truffleruby-head
         runs-on:
-        - ubuntu-latest
+          - ubuntu-latest
 
     runs-on: ${{ matrix.runs-on }}
 
     steps:
 
-    - uses: actions/checkout@v2
+      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
 
-    - uses: ruby/setup-ruby@v1
-      with:
-        ruby-version: ${{ matrix.ruby-version }}
-        bundler-cache: true
+      - uses: ruby/setup-ruby@319994f95fa847cf3fb3cd3dbe89f6dcde9f178f # v1
+        with:
+          ruby-version: ${{ matrix.ruby-version }}
+          bundler-cache: true
 
-    - run: bundle exec rake test
+      - run: bundle exec rake test


### PR DESCRIPTION
# Pin GitHub Actions to commit SHAs

## Description of change

Pins all third-party GitHub Actions to specific commit SHAs to protect
against tag hijacking / supply chain attacks. Actions from the `rewindio`
org are excluded and remain at their original version refs.

Uses [ratchet](https://github.com/sethvargo/ratchet) for SHA resolution.

## Testing Performed
